### PR TITLE
Add build instructions for macOS

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -21,6 +21,12 @@ autoconf, automake, libtool, and pkg-config and then run
 
 This will create the ``configure`` script required for building library and executable tools.
 
+* For macOS, one option is to first install  `homebrew <https://brew.sh/>`_ and then run the following before running `autoreconf`
+
+.. code:: bash
+
+    brew install autoconf automake libtool check
+
 
 Build configuration
 +++++++++++++++++++


### PR DESCRIPTION
Not sure if the best way to format platform-specific instructions, but this is the command I needed for a mac build.