### PR TITLE
meson: fixes for using libdicom as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project(
     'warning_level=2',
   ],
   license : 'MIT',
-  meson_version : '>=0.50',
+  meson_version : '>=0.54',
   version : '0.1.0',
 )
 meson.add_dist_script(
@@ -150,6 +150,7 @@ libdicom_dep = declare_dependency(
   include_directories : library_includes,
   link_with : libdicom,
 )
+meson.override_dependency('libdicom', libdicom_dep)
 
 # tools
 executable(

--- a/meson.build
+++ b/meson.build
@@ -9,9 +9,11 @@ project(
   meson_version : '>=0.54',
   version : '0.1.0',
 )
-meson.add_dist_script(
-  'scripts/dist.py'
-)
+if not meson.is_subproject()
+  meson.add_dist_script(
+    'scripts/dist.py'
+  )
+endif
 
 # project version
 version_parts = meson.project_version().split('.')


### PR DESCRIPTION
Add an `override_dependency()` call for libdicom.  This is the modern way of propagating dependencies out of subprojects, allowing a parent project to use `dependency('libdicom')` rather than `dependency('libdicom', fallback : ['libdicom', 'libdicom_dep'])`.

Also skip the dist script if we're a subproject.  Dist scripts can't be used in subprojects before Meson 0.58.0, and in our case, it's not clear that it makes sense to do so.  The parent project probably doesn't want to ship our documentation, may not have vendored our dotfiles, and may not want us skipping files they did choose to vendor.