### PR TITLE
workflows: rename master branch to main

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -2,9 +2,9 @@ name: build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
I believe this is the only code change needed to implement #28.  Marking as draft until the branch rename occurs; this PR should then be merged immediately afterward.