### PR TITLE
Rename dcmfile

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -116,7 +116,7 @@ typedef SSIZE_T ssize_t;
 /**
  * Part10 file
  */
-typedef struct _DcmFile DcmFile;
+typedef struct _DcmFilehandle DcmFilehandle;
 
 /**
  * Data Element
@@ -2319,7 +2319,7 @@ void dcm_frame_destroy(DcmFrame *frame);
  *                 (measured from the first byte of the first Frame).
  * :param num_frames: Number of Frames in the Pixel Data Element
  * :first_frame_offset: Offset from pixel_data_offset to the first byte of the
- * 			first frame
+ *                      first frame
  *
  * The created object takes over ownership of the memory referenced by `offsets`
  * and frees it when the object is destroyed or if the creation fails.
@@ -2329,7 +2329,7 @@ void dcm_frame_destroy(DcmFrame *frame);
 DCM_EXTERN
 DcmBOT *dcm_bot_create(DcmError **error,
                        ssize_t *offsets, uint32_t num_frames, 
-		       ssize_t first_frame_offset);
+                       ssize_t first_frame_offset);
 
 /**
  * Get number of Frame offsets in the Basic Offset Table.
@@ -2374,7 +2374,7 @@ void dcm_bot_destroy(DcmBOT *bot);
  */
 
 /**
- * A set of IO functions, see dcm_file_create_io().
+ * A set of IO functions, see dcm_filehandle_create().
  */
 typedef struct _DcmIO {
     /** Open an IO object */
@@ -2388,69 +2388,73 @@ typedef struct _DcmIO {
 } DcmIO;
 
 /**
- * Create a File that reads using a set of DcmIO functions.
+ * Create a filehandle that reads using a set of DcmIO functions.
  *
  * :param error: Error structure pointer
- * :param io: Set of read functions for this DcmFile
+ * :param io: Set of read functions for this DcmFilehandle
  * :param client: Client data for read functions
  *
- * :return: file
+ * :return: filehandle
  */
 DCM_EXTERN
-DcmFile *dcm_file_create_io(DcmError **error, DcmIO *io, void *client); 
+DcmFilehandle *dcm_filehandle_create(DcmError **error, DcmIO *io, void *client); 
 
 /**
- * Open a file on disk as a DcmFile.
+ * Open a file on disk as a DcmFilehandle.
  *
  * :param error: Error structure pointer
- * :param file_path: Path to the file on disk
+ * :param filepath: Path to the file on disk
  *
- * :return: file
+ * :return: filehandle
  */
 DCM_EXTERN
-DcmFile *dcm_file_open(DcmError **error, const char *file_path);
+DcmFilehandle *dcm_filehandle_create_from_file(DcmError **error, 
+                                               const char *filepath);
 
 /**
- * Open an area of memory as a DcmFile.
+ * Open an area of memory as a DcmFilehandle.
  *
  * :param error: Error structure pointer
  * :param buffer: Pointer to memory area
  * :param length: Length of memory area in bytes
  *
- * :return: file
+ * :return: filehandle
  */
 DCM_EXTERN
-DcmFile *dcm_file_memory(DcmError **error, char *buffer, int64_t length);
+DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error, 
+                                                 char *buffer, int64_t length);
 
 /**
  * Read File Metainformation from a File.
  *
  * Keeps track of the offset of the Data Set relative to the beginning of the
- * file to speed up subsequent access and determines the transfer syntax in
- * which the contained Data Set is encoded.
+ * filehandle to speed up subsequent access, and determines the transfer 
+ * syntax in which the contained Data Set is encoded.
  *
  * :param error: Error structure pointer
- * :param file: File
+ * :param filehandle: File
  *
  * :return: File Metainformation
  */
 DCM_EXTERN
-DcmDataSet *dcm_file_read_file_meta(DcmError **error, DcmFile *file);
+DcmDataSet *dcm_filehandle_read_filehandle_meta(DcmError **error, 
+                                                DcmFilehandle *filehandle);
 
 /**
  * Read metadata from a File.
  *
  * Keeps track of the offset of the Pixel Data Element relative to the 
- * beginning of the file to speed up subsequent access to individual 
+ * beginning of the filehandle to speed up subsequent access to individual 
  * Frame items.
  *
  * :param error: Error structure pointer
- * :param file: File
+ * :param filehandle: File
  *
  * :return: metadata
  */
 DCM_EXTERN
-DcmDataSet *dcm_file_read_metadata(DcmError **error, DcmFile *file);
+DcmDataSet *dcm_filehandle_read_metadata(DcmError **error, 
+                                         DcmFilehandle *filehandle);
 
 /**
  * Read Basic Offset Table from a File.
@@ -2460,33 +2464,33 @@ DcmDataSet *dcm_file_read_metadata(DcmError **error, DcmFile *file);
  * Offset Table element will be read instead.
  *
  * :param error: Error structure pointer
- * :param file: File
+ * :param filehandle: File
  * :param metadata: Metadata
  *
  * :return: Basic Offset Table
  */
 DCM_EXTERN
-DcmBOT *dcm_file_read_bot(DcmError **error, DcmFile *file,
-                          DcmDataSet *metadata);
+DcmBOT *dcm_filehandle_read_bot(DcmError **error, DcmFilehandle *filehandle,
+                                DcmDataSet *metadata);
 
 /**
  * Build Basic Offset Table for a File.
  *
  * :param error: Error structure pointer
- * :param file: File
+ * :param filehandle: File
  * :param metadata: Metadata
  *
  * :return: Basic Offset Table
  */
 DCM_EXTERN
-DcmBOT *dcm_file_build_bot(DcmError **error, DcmFile *file, 
-			   DcmDataSet *metadata);
+DcmBOT *dcm_filehandle_build_bot(DcmError **error, DcmFilehandle *filehandle, 
+                                 DcmDataSet *metadata);
 
 /**
  * Read an individual Frame from a File.
  *
  * :param error: Error structure pointer
- * :param file: File
+ * :param filehandle: File
  * :param metadata: Metadata
  * :param bot: Basic Offset Table
  * :param index: Zero-based offset of the Frame in the Pixel Data Element
@@ -2494,18 +2498,18 @@ DcmBOT *dcm_file_build_bot(DcmError **error, DcmFile *file,
  * :return: Frame
  */
 DCM_EXTERN
-DcmFrame *dcm_file_read_frame(DcmError **error,
-                              DcmFile *file,
-                              DcmDataSet *metadata,
-                              DcmBOT *bot,
-                              uint32_t index);
+DcmFrame *dcm_filehandle_read_frame(DcmError **error,
+                                    DcmFilehandle *filehandle,
+                                    DcmDataSet *metadata,
+                                    DcmBOT *bot,
+                                    uint32_t index);
 
 /**
  * Destroy a File.
  *
- * :param file: File
+ * :param filehandle: File
  */
 DCM_EXTERN
-void dcm_file_destroy(DcmFile *file);
+void dcm_filehandle_destroy(DcmFilehandle *filehandle);
 
 #endif

--- a/src/dicom-io.c
+++ b/src/dicom-io.c
@@ -38,55 +38,55 @@
 
 typedef struct _DcmIOFile {
     int fd;
-    char *filename;
+    char *filehandlename;
     char input_buffer[BUFFER_SIZE];
     int bytes_in_buffer;
     int read_point;
 } DcmIOFile;
 
 
-static int dcm_io_close_file(DcmError **error, void *data)
+static int dcm_io_close_filehandle(DcmError **error, void *data)
 {
-    DcmIOFile *io_file = (DcmIOFile *) data;
+    DcmIOFile *io_filehandle = (DcmIOFile *) data;
 
     int close_errno = 0;
 
-    if (io_file->fd != -1) {
-        if (close(io_file->fd)) {
+    if (io_filehandle->fd != -1) {
+        if (close(io_filehandle->fd)) {
             close_errno = errno;
         }
 
-        io_file->fd = -1;
+        io_filehandle->fd = -1;
 
         if (close_errno) {
             dcm_error_set(error, DCM_ERROR_CODE_IO,
-                "Unable to close file",
+                "Unable to close filehandle",
                 "Unable to close %s - %s", 
-                io_file->filename, strerror(close_errno));
+                io_filehandle->filehandlename, strerror(close_errno));
         }
     }
 
-    free(io_file->filename);
-    free(io_file);
+    free(io_filehandle->filehandlename);
+    free(io_filehandle);
 
     return close_errno;
 }
 
 
-static void *dcm_io_open_file(DcmError **error, void *client)
+static void *dcm_io_open_filehandle(DcmError **error, void *client)
 {
-    DcmIOFile *io_file = DCM_NEW(error, DcmIOFile);
-    if (io_file == NULL) {
+    DcmIOFile *io_filehandle = DCM_NEW(error, DcmIOFile);
+    if (io_filehandle == NULL) {
         return NULL;
     }
 
     // The "not set" value for fd
-    io_file->fd = -1;
+    io_filehandle->fd = -1;
 
-    const char *filename = (const char *) client;
-    io_file->filename = dcm_strdup(error, filename);
-    if (io_file->filename == NULL) {
-        dcm_io_close_file(error, io_file);
+    const char *filehandlename = (const char *) client;
+    io_filehandle->filehandlename = dcm_strdup(error, filehandlename);
+    if (io_filehandle->filehandlename == NULL) {
+        dcm_io_close_filehandle(error, io_filehandle);
         return NULL;
     }
 
@@ -96,7 +96,7 @@ static void *dcm_io_open_file(DcmError **error, void *client)
     int oflag = _O_BINARY | _O_RDONLY | _O_RANDOM;
     int shflag = _SH_DENYWR;
     int pmode = 0;
-    open_errno = _sopen_s(&io_file->fd, io_file->filename, 
+    open_errno = _sopen_s(&io_filehandle->fd, io_filehandle->filehandlename, 
                           oflag, shflag, pmode);
 #else
     int flags = O_RDONLY;
@@ -105,41 +105,41 @@ static void *dcm_io_open_file(DcmError **error, void *client)
 #endif
     mode_t mode = 0;
     do
-        io_file->fd = open(io_file->filename, flags, mode);
-    while (io_file->fd == -1 && errno == EINTR);
+        io_filehandle->fd = open(io_filehandle->filehandlename, flags, mode);
+    while (io_filehandle->fd == -1 && errno == EINTR);
 
     open_errno = errno;
 #endif
 
-    if (io_file->fd == -1) {
+    if (io_filehandle->fd == -1) {
         dcm_error_set(error, DCM_ERROR_CODE_IO,
-            "Unable to open file",
-            "Unable to open %s - %s", io_file->filename, strerror(open_errno));
-        dcm_io_close_file(error, io_file);
+            "Unable to open filehandle",
+            "Unable to open %s - %s", io_filehandle->filehandlename, strerror(open_errno));
+        dcm_io_close_filehandle(error, io_filehandle);
         return NULL;
     }
 
-    return io_file;
+    return io_filehandle;
 }
 
 
-static int64_t read_file(DcmError **error, DcmIOFile *io_file,
+static int64_t read_filehandle(DcmError **error, DcmIOFile *io_filehandle,
     char *buffer, int64_t length)
 {
     int64_t bytes_read;
 
 #ifdef _WIN32
-    bytes_read = _read(io_file->fd, buffer, length);
+    bytes_read = _read(io_filehandle->fd, buffer, length);
 #else
     do {
-        bytes_read = read(io_file->fd, buffer, length);
+        bytes_read = read(io_filehandle->fd, buffer, length);
     } while (bytes_read < 0 && errno == EINTR);
 #endif
 
     if (bytes_read < 0) {
         dcm_error_set(error, DCM_ERROR_CODE_IO,
-            "Unable to read from file",
-            "Unable to read %s - %s", io_file->filename, strerror(errno));
+            "Unable to read from filehandle",
+            "Unable to read %s - %s", io_filehandle->filehandlename, strerror(errno));
     }
 
     return bytes_read;
@@ -149,35 +149,35 @@ static int64_t read_file(DcmError **error, DcmIOFile *io_file,
 /* Refill the input buffer. 
  * -1 on error, 0 on EOF, otherwise bytes read.
  */
-static int64_t refill(DcmError **error, DcmIOFile *io_file)
+static int64_t refill(DcmError **error, DcmIOFile *io_filehandle)
 {
     // buffer should be empty coming in
-    assert(io_file->bytes_in_buffer - io_file->read_point == 0);
+    assert(io_filehandle->bytes_in_buffer - io_filehandle->read_point == 0);
 
-    int64_t bytes_read = read_file(error, io_file, 
-                                   io_file->input_buffer, BUFFER_SIZE); 
+    int64_t bytes_read = read_filehandle(error, io_filehandle, 
+                                   io_filehandle->input_buffer, BUFFER_SIZE); 
     if (bytes_read < 0) {
         return bytes_read;
     }
 
-    io_file->read_point = 0;
-    io_file->bytes_in_buffer = bytes_read;
+    io_filehandle->read_point = 0;
+    io_filehandle->bytes_in_buffer = bytes_read;
 
     return bytes_read;
 }
 
 
-static int64_t dcm_io_read_file(DcmError **error, void *data, 
+static int64_t dcm_io_read_filehandle(DcmError **error, void *data, 
     char *buffer, int64_t length)
 {
-    DcmIOFile *io_file = (DcmIOFile *) data;
+    DcmIOFile *io_filehandle = (DcmIOFile *) data;
     int64_t bytes_read = 0;
 
     while (length > 0) {
         /* Refill the input buffer if it's empty.
          */
-        if (io_file->bytes_in_buffer - io_file->read_point == 0) {
-            int64_t refill_bytes = refill(error, io_file);
+        if (io_filehandle->bytes_in_buffer - io_filehandle->read_point == 0) {
+            int64_t refill_bytes = refill(error, io_filehandle);
             if (refill_bytes < 0) {
                 return refill_bytes;
             } else if (refill_bytes == 0) {
@@ -188,16 +188,16 @@ static int64_t dcm_io_read_file(DcmError **error, void *data,
 
         /* Read what we can from the buffer.
          */
-        int bytes_available = io_file->bytes_in_buffer - io_file->read_point;
+        int bytes_available = io_filehandle->bytes_in_buffer - io_filehandle->read_point;
         int bytes_to_copy = MIN(bytes_available, length);
 
         memcpy(buffer, 
-               io_file->input_buffer + io_file->read_point, 
+               io_filehandle->input_buffer + io_filehandle->read_point, 
                bytes_to_copy);
         length -= bytes_to_copy;
         buffer += bytes_to_copy;
 
-        io_file->read_point += bytes_to_copy;
+        io_filehandle->read_point += bytes_to_copy;
         bytes_read += bytes_to_copy;
     }
 
@@ -205,67 +205,63 @@ static int64_t dcm_io_read_file(DcmError **error, void *data,
 }
 
 
-static int64_t dcm_io_seek_file(DcmError **error, void *data, 
+static int64_t dcm_io_seek_filehandle(DcmError **error, void *data, 
     int64_t offset, int whence)
 {
-    DcmIOFile *io_file = (DcmIOFile *) data;
+    DcmIOFile *io_filehandle = (DcmIOFile *) data;
 
     /* We've read ahead by some number of buffered bytes, so first undo that,
      * then do the seek from the true position.
      */
     int64_t new_offset;
 
-    int64_t bytes_ahead = io_file->bytes_in_buffer - io_file->read_point;
+    int64_t bytes_ahead = io_filehandle->bytes_in_buffer - io_filehandle->read_point;
     if (bytes_ahead > 0) {
 #ifdef _WIN32
-        new_offset = _lseeki64(io_file->fd, -bytes_ahead, SEEK_CUR);
+        new_offset = _lseeki64(io_filehandle->fd, -bytes_ahead, SEEK_CUR);
 #else
-        new_offset = lseek(io_file->fd, -bytes_ahead, SEEK_CUR);
+        new_offset = lseek(io_filehandle->fd, -bytes_ahead, SEEK_CUR);
 #endif
 
         if (new_offset < 0) {
             dcm_error_set(error, DCM_ERROR_CODE_IO,
-                "Unable to seek file",
-                "Unable to seek %s - %s", io_file->filename, strerror(errno));
+                "Unable to seek filehandle",
+                "Unable to seek %s - %s", io_filehandle->filehandlename, strerror(errno));
         }
     }
 
 #ifdef _WIN32
-    new_offset = _lseeki64(io_file->fd, offset, whence);
+    new_offset = _lseeki64(io_filehandle->fd, offset, whence);
 #else
-    new_offset = lseek(io_file->fd, offset, whence);
+    new_offset = lseek(io_filehandle->fd, offset, whence);
 #endif
 
     if (new_offset < 0) {
         dcm_error_set(error, DCM_ERROR_CODE_IO,
-            "Unable to seek file",
-            "Unable to seek %s - %s", io_file->filename, strerror(errno));
+            "Unable to seek filehandle",
+            "Unable to seek %s - %s", io_filehandle->filehandlename, strerror(errno));
     }
 
     /* Empty the buffer, since we may now be at a different position.
      */
-    io_file->bytes_in_buffer = 0;
-    io_file->read_point = 0;
+    io_filehandle->bytes_in_buffer = 0;
+    io_filehandle->read_point = 0;
 
     return new_offset;
 }
 
 
-DcmFile *dcm_file_open(DcmError **error, const char *file_path)
+DcmFilehandle *dcm_filehandle_create_from_file(DcmError **error, 
+                                               const char *filehandle_path)
 {
     static DcmIO io = {
-        dcm_io_open_file,
-        dcm_io_close_file,
-        dcm_io_read_file,
-        dcm_io_seek_file,
+        dcm_io_open_filehandle,
+        dcm_io_close_filehandle,
+        dcm_io_read_filehandle,
+        dcm_io_seek_filehandle,
     };
 
-    DcmFile *file = dcm_file_create_io(error, &io, (void *) file_path);
-    if (file == NULL) {
-        return NULL;
-    }
-
-    return file;
+    return dcm_filehandle_create(error, &io, (void *) filehandle_path);
 }
 
 
@@ -354,7 +350,8 @@ static int64_t dcm_io_seek_memory(DcmError **error, void *data,
 }
 
 
-DcmFile *dcm_file_memory(DcmError **error, char *buffer, int64_t length)
+DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error, 
+                                                 char *buffer, int64_t length)
 {
     static DcmIO io = {
         dcm_io_open_memory,
@@ -363,18 +360,11 @@ DcmFile *dcm_file_memory(DcmError **error, char *buffer, int64_t length)
         dcm_io_seek_memory,
     };
 
-    DcmIOMemory *memory = DCM_NEW(error, DcmIOMemory);
-    if (memory == NULL) {
-        return NULL;
-    }
-    memory->buffer = buffer;
-    memory->length = length;
+    DcmIOMemory memory = {
+        buffer,
+        length,
+        0
+    };
 
-    DcmFile *file = dcm_file_create_io(error, &io, memory);
-    free(memory);
-    if (file == NULL) {
-        return NULL;
-    }
-
-    return file;
+    return dcm_filehandle_create(error, &io, &memory);
 }

--- a/tools/dcm-dump.c
+++ b/tools/dcm-dump.c
@@ -16,8 +16,8 @@ int main(int argc, char *argv[])
     const char *file_path = NULL;
     DcmError *error = NULL;
     DcmDataSet *metadata = NULL;
-    DcmDataSet *file_meta = NULL;
-    DcmFile *file = NULL;
+    DcmDataSet *filehandle_meta = NULL;
+    DcmFilehandle *filehandle = NULL;
 
     dcm_log_level = DCM_LOG_ERROR;
 
@@ -44,40 +44,40 @@ int main(int argc, char *argv[])
     }
     file_path = argv[i];
 
-    dcm_log_info("Read file '%s'", file_path);
-    file = dcm_file_open(&error, file_path);
-    if (file == NULL) {
+    dcm_log_info("Read filehandle '%s'", file_path);
+    filehandle = dcm_filehandle_create_from_file(&error, file_path);
+    if (filehandle == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
         return EXIT_FAILURE;
     }
     dcm_log_info("Read File Meta Information");
-    file_meta = dcm_file_read_file_meta(&error, file);
-    if (file_meta == NULL) {
+    filehandle_meta = dcm_filehandle_read_filehandle_meta(&error, filehandle);
+    if (filehandle_meta == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
-        dcm_file_destroy(file);
+        dcm_filehandle_destroy(filehandle);
         return EXIT_FAILURE;
     }
 
     printf("===File Meta Information===\n");
-    dcm_dataset_print(file_meta, 0);
+    dcm_dataset_print(filehandle_meta, 0);
 
     dcm_log_info("Read metadata");
-    metadata = dcm_file_read_metadata(&error, file);
+    metadata = dcm_filehandle_read_metadata(&error, filehandle);
     if (metadata == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
-        dcm_file_destroy(file);
-        dcm_dataset_destroy(file_meta);
+        dcm_filehandle_destroy(filehandle);
+        dcm_dataset_destroy(filehandle_meta);
         return EXIT_FAILURE;
     }
 
     printf("===Dataset===\n");
     dcm_dataset_print(metadata, 0);
 
-    dcm_file_destroy(file);
-    dcm_dataset_destroy(file_meta);
+    dcm_filehandle_destroy(filehandle);
+    dcm_dataset_destroy(filehandle_meta);
     dcm_dataset_destroy(metadata);
 
     return EXIT_SUCCESS;

--- a/tools/dcm-getframe.c
+++ b/tools/dcm-getframe.c
@@ -16,7 +16,7 @@ static const char usage[] = "usage: dcm-getframe [-v] [-V] [-h] [-o OUTPUT-FILE]
 int main(int argc, char *argv[]) 
 {
     DcmError *error = NULL;
-    char *output_file = NULL;
+    char *output_filehandle = NULL;
     int i;
 
     dcm_log_level = DCM_LOG_ERROR;
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
                 dcm_log_level = DCM_LOG_INFO;
                 break;
             case 'o':
-                output_file = argv[i + 1];
+                output_filehandle = argv[i + 1];
                 i += 1;
                 break;
             default:
@@ -50,37 +50,38 @@ int main(int argc, char *argv[])
 
     uint32_t frame_number = atoi(argv[i + 1]);
 
-    dcm_log_info("Read file '%s'", file_path);
-    DcmFile *file = dcm_file_open(&error, file_path);
-    if (file == NULL) {
+    dcm_log_info("Read filehandle '%s'", file_path);
+    DcmFilehandle *filehandle = dcm_filehandle_create_from_file(&error, 
+                                                                file_path);
+    if (filehandle == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
         return EXIT_FAILURE;
     }
 
     dcm_log_info("Read metadata");
-    DcmDataSet *metadata = dcm_file_read_metadata(&error, file);
+    DcmDataSet *metadata = dcm_filehandle_read_metadata(&error, filehandle);
     if (metadata == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
-        dcm_file_destroy(file);
+        dcm_filehandle_destroy(filehandle);
         return EXIT_FAILURE;
     }
 
     dcm_log_info("Read BOT");
-    DcmBOT *bot = dcm_file_read_bot(&error, file, metadata);
+    DcmBOT *bot = dcm_filehandle_read_bot(&error, filehandle, metadata);
     if (bot == NULL) {
         /* Try to build the BOT instead.
          */
         dcm_error_clear(&error);
         dcm_log_info("Build BOT");
-        bot = dcm_file_build_bot(&error, file, metadata);
+        bot = dcm_filehandle_build_bot(&error, filehandle, metadata);
     }
     if (bot == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
         dcm_dataset_destroy(metadata);
-        dcm_file_destroy(file);
+        dcm_filehandle_destroy(filehandle);
         return EXIT_FAILURE;
     }
 
@@ -94,19 +95,20 @@ int main(int argc, char *argv[])
         dcm_error_clear(&error);
         dcm_bot_destroy(bot);
         dcm_dataset_destroy(metadata);
-        dcm_file_destroy(file);
+        dcm_filehandle_destroy(filehandle);
         return EXIT_FAILURE;
     }
 
     dcm_log_info("Read frame %u", frame_number);
-    DcmFrame *frame = dcm_file_read_frame(&error, 
-                                          file, metadata, bot, frame_number);
+    DcmFrame *frame = dcm_filehandle_read_frame(&error, 
+                                                filehandle, metadata, 
+                                                bot, frame_number);
     if (frame == NULL) {
         dcm_error_log(error);
         dcm_error_clear(&error);
         dcm_bot_destroy(bot);
         dcm_dataset_destroy(metadata);
-        dcm_file_destroy(file);
+        dcm_filehandle_destroy(filehandle);
         return EXIT_FAILURE;
     }
 
@@ -132,12 +134,12 @@ int main(int argc, char *argv[])
                  dcm_frame_get_transfer_syntax_uid(frame));
 
     FILE *output_fp;
-    if (output_file != NULL) {
-        output_fp = fopen(output_file, "wb");
+    if (output_filehandle != NULL) {
+        output_fp = fopen(output_filehandle, "wb");
         if (output_fp == NULL) {
             dcm_error_set(&error, DCM_ERROR_CODE_INVALID,
-                          "Bad output file name",
-                          "Unable to open %s for output", output_file);
+                          "Bad output filehandle name",
+                          "Unable to open %s for output", output_filehandle);
         }
     }
     else
@@ -145,7 +147,7 @@ int main(int argc, char *argv[])
 
     fwrite(frame_value, 1, frame_length, output_fp);
 
-    if (output_file != NULL) {
+    if (output_filehandle != NULL) {
         fclose(output_fp);
         output_fp = NULL;
     }
@@ -153,7 +155,7 @@ int main(int argc, char *argv[])
     dcm_frame_destroy(frame);
     dcm_bot_destroy(bot);
     dcm_dataset_destroy(metadata);
-    dcm_file_destroy(file);
+    dcm_filehandle_destroy(filehandle);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR renames DcmFile as DcmFilehandle.

`dcm_filehandle_create_from_file()` to open a file on disc.

`dcm_filehandle_create_from_memory()` to open a memory area.

Docs updated too.