### PR TITLE
meson: add option to disable tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,13 +74,15 @@ else
   # --wrap-mode=nofallback works
   uthash = dependency('uthash')
 endif
-check = dependency(
-  'check',
-  default_options : [
-    'warning_level=0',
-  ],
-  version : '>=0.9.6',
-)
+if get_option('tests')
+  check = dependency(
+    'check',
+    default_options : [
+      'warning_level=0',
+    ],
+    version : '>=0.9.6',
+  )
+endif
 
 # options
 cfg = configuration_data()
@@ -218,9 +220,11 @@ custom_target(
 )
 
 # tests
-check_dicom = executable(
-  'check_dicom',
-  'tests/check_dicom.c',
-  dependencies : [check, libdicom_dep],
-)
-test('check_dicom', check_dicom)
+if get_option('tests')
+  check_dicom = executable(
+    'check_dicom',
+    'tests/check_dicom.c',
+    dependencies : [check, libdicom_dep],
+  )
+  test('check_dicom', check_dicom)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,9 @@ option(
   type : 'string',
   description : 'suffix to append to the package version string',
 )
+option(
+  'tests',
+  type : 'boolean',
+  value : true,
+  description : 'build tests',
+)


### PR DESCRIPTION
The `check` dependency is only needed for building tests.  Allow avoiding it by disabling tests.  However, require an explicit configuration setting to do so, and continue making `check` mandatory when tests are enabled, so users/packagers can't accidentally skip running tests when they intend to do so.

This is a partial reversal of a change I made in #23, which assumed that the wrapdb fallback made it okay to require `check`.  That's fine for end users, but requires openslide-winbuild (which doesn't use wraps from subprojects) to carry a `check` wrap even though it has no intention of running unit tests.  This PR splits the difference by making the disablement entirely manual, rather than basing it on the result of feature detection.