### PR TITLE
Windows build fixes

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -13,7 +13,9 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifdef _WIN32
-#ifdef BUILDING_LIBDICOM
+#if DCM_STATIC
+#define DCM_EXTERN extern
+#elif defined(BUILDING_LIBDICOM)
 #define DCM_EXTERN __declspec(dllexport) extern
 #else
 #define DCM_EXTERN __declspec(dllimport) extern

--- a/include/dicom/version.h.in
+++ b/include/dicom/version.h.in
@@ -15,6 +15,10 @@
 #define DCM_ABI_VERSION_MINOR  (@DCM_ABI_VERSION_MINOR@)
 #define DCM_ABI_VERSION_PATCH  (@DCM_ABI_VERSION_PATCH@)
 
+/* Whether libdicom is built statically.
+ */
+#define DCM_STATIC             (@DCM_STATIC@)
+
 #endif /*DCM_VERSION_H*/
 
 

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ version_data.set('DCM_VERSION_MICRO', version_patch)
 version_data.set('DCM_ABI_VERSION_MAJOR', abi_version_major)
 version_data.set('DCM_ABI_VERSION_MINOR', abi_version_minor)
 version_data.set('DCM_ABI_VERSION_PATCH', abi_version_patch)
+version_data.set10('DCM_STATIC', get_option('default_library') == 'static')
 
 # dependencies
 cc = meson.get_compiler('c')

--- a/src/dicom-io.c
+++ b/src/dicom-io.c
@@ -10,6 +10,7 @@
 #define _CRT_NONSTDC_NO_DEPRECATE
 // and deprecates strdup
 #define strdup(v) _strdup(v)
+#include <share.h>
 #endif
 
 #include <assert.h>


### PR DESCRIPTION
Include `share.h` from `dicom-io.c` on Windows to fix missing definition for `_SH_DENYWR`.

Don't `dllexport`/`dllimport` when building libdicom as a static library.  In this case, we don't want callers to try to mangle our symbols to reference them from a DLL import library, and we don't want to include our symbols in the exports of a larger DLL that we might be linked into.