### PR TITLE
meson: reduce minimum supported Meson version to 0.50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     'warning_level=2',
   ],
   license : 'MIT',
-  meson_version : '>=0.54',
+  meson_version : '>=0.50',
   version : '0.1.0',
 )
 if not meson.is_subproject()
@@ -172,7 +172,9 @@ libdicom_dep = declare_dependency(
   include_directories : library_includes,
   link_with : libdicom,
 )
-meson.override_dependency('libdicom', libdicom_dep)
+if meson.version().version_compare('>=0.54')
+  meson.override_dependency('libdicom', libdicom_dep)
+endif
 
 # tools
 executable(


### PR DESCRIPTION
OpenSlide supports &ge; 0.53.  The only Meson feature we use that requires > 0.50 is `meson.override_dependency()`, which can safely be skipped on older versions.