### PR TITLE
meson: explicitly specify fallbacks for `uthash` and `check`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,10 @@ if found_uthash
 else
   # fall back to dependency() rather than subproject() so
   # --wrap-mode=nofallback works
-  uthash = dependency('uthash')
+  uthash = dependency(
+    'uthash',
+    fallback : ['uthash', 'uthash_dep'],
+  )
 endif
 if get_option('tests')
   check = dependency(
@@ -81,6 +84,7 @@ if get_option('tests')
     default_options : [
       'warning_level=0',
     ],
+    fallback : ['check', 'check_dep'],
     version : '>=0.9.6',
   )
 endif


### PR DESCRIPTION
Meson 0.55 added automatic fallback to wraps in the subprojects directory, and 0.54 added the single-string argument to `fallback`.  Use the old two-argument form to properly support fallback on older Meson.