### PR TITLE
dicom.h: note some one-based indexes

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -2347,7 +2347,7 @@ uint32_t dcm_bot_get_num_frames(const DcmBOT *bot);
  * Get Frame offset in the Basic Offset Table.
  *
  * :param bot: Basic Offset Table
- * :param index: Zero-based index of Frame in the Pixel Data Element
+ * :param index: One-based index of Frame in the Pixel Data Element
  *
  * :return: offset from pixel_data_offset
  */
@@ -2495,7 +2495,7 @@ DcmBOT *dcm_filehandle_build_bot(DcmError **error, DcmFilehandle *filehandle,
  * :param filehandle: File
  * :param metadata: Metadata
  * :param bot: Basic Offset Table
- * :param index: Zero-based offset of the Frame in the Pixel Data Element
+ * :param index: One-based offset of the Frame in the Pixel Data Element
  *
  * :return: Frame
  */


### PR DESCRIPTION
A couple functions are documented to take zero-based index parameters but actually take one-based indexes.  For now, update docs to match the current API.  Should these functions be switched to zero-indexed for consistency?