### PR TITLE
Fix memory filehandles

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -2423,8 +2423,9 @@ DcmFilehandle *dcm_filehandle_create_from_file(DcmError **error,
  * :return: filehandle
  */
 DCM_EXTERN
-DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error, 
-                                                 char *buffer, int64_t length);
+DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error,
+                                                 const char *buffer,
+                                                 int64_t length);
 
 /**
  * Read File Metainformation from a File.

--- a/src/dicom-io.c
+++ b/src/dicom-io.c
@@ -267,7 +267,7 @@ DcmFilehandle *dcm_filehandle_create_from_file(DcmError **error,
 
 
 typedef struct _DcmIOMemory {
-    char *buffer;
+    const char *buffer;
     int64_t length;
     int64_t read_point;
 } DcmIOMemory;
@@ -351,8 +351,9 @@ static int64_t dcm_io_seek_memory(DcmError **error, void *data,
 }
 
 
-DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error, 
-                                                 char *buffer, int64_t length)
+DcmFilehandle *dcm_filehandle_create_from_memory(DcmError **error,
+                                                 const char *buffer,
+                                                 int64_t length)
 {
     static DcmIO io = {
         dcm_io_open_memory,

--- a/src/dicom-io.c
+++ b/src/dicom-io.c
@@ -345,9 +345,9 @@ static int64_t dcm_io_seek_memory(DcmError **error, void *data,
             return -1;
     }
 
-    new_offset = MAX(0, MIN(new_offset, io_memory->length));
+    io_memory->read_point = MAX(0, MIN(new_offset, io_memory->length));
 
-    return new_offset;
+    return io_memory->read_point;
 }
 
 


### PR DESCRIPTION
Remember to record the new offset when seeking.

While we're here, constify the input buffer.