### PR TITLE
Revert Meson version bump to support Ubuntu 20.04

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,8 +7,7 @@ project(
     'warning_level=2',
   ],
   license : 'MIT',
-  # "check" needs 0.54.1
-  meson_version : '>=0.54.1',
+  meson_version : '>=0.50',
   version : '1.0.0'
 )
 if not meson.is_subproject()


### PR DESCRIPTION
OpenSlide supports Meson down to 0.53, which is the version in Ubuntu 20.04.  OpenSlide disables libdicom's tests when falling back to the libdicom wrap, circumventing check's requirement for a newer Meson.

This reverts commit ec925f319136d74eadb8e4c2284511b4c4acda3f.