### PR TITLE
meson: omit Sphinx doctrees from dist tarball

### DIFF
--- a/scripts/dist.py
+++ b/scripts/dist.py
@@ -14,3 +14,4 @@ shutil.rmtree(base / '.github')
 # build docs and add them to the tarball
 subprocess.run(['meson', 'compile', 'html'], check=True)
 shutil.copytree('html', base / 'doc/html', symlinks=True)
+shutil.rmtree(base / 'doc/html/.doctrees')


### PR DESCRIPTION
They're only needed when building the documentation.  Saves 1.9 MiB uncompressed, 0.2 MiB compressed.