### PR TITLE
workflows: update actions/checkout to v4

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,6 +11,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             cc: clang
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install build and test dependencies (Linux)
       if: startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
No breaking changes.  v3 uses an old version of Node that will start [throwing deprecation warnings](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) soon.