### PR TITLE
tools: correct project name in man page footer

### DIFF
--- a/tools/dcm-dump.1.in
+++ b/tools/dcm-dump.1.in
@@ -1,4 +1,4 @@
-.TH DCM-DUMP 1 2020-07-18 "dcm @DCM_SUFFIXED_VERSION@" "User Commands"
+.TH DCM-DUMP 1 2023-09-30 "libdicom @DCM_SUFFIXED_VERSION@" "User Commands"
 
 .SH NAME
 dcm-dump \- print metadata content of DICOM PS3.10 file to standard output

--- a/tools/dcm-getframe.1.in
+++ b/tools/dcm-getframe.1.in
@@ -1,4 +1,4 @@
-.TH DCM-GETFRAME 1 2023-01-14 "dcm @DCM_SUFFIXED_VERSION@" "User Commands"
+.TH DCM-GETFRAME 1 2023-09-30 "libdicom @DCM_SUFFIXED_VERSION@" "User Commands"
 
 .SH NAME
 dcm-getframe \- print a frame from a DICOM PS3.10 file to standard output


### PR DESCRIPTION
The man pages claim to be from the `dcm` project, which is confusing. Use `libdicom` instead.