### PR TITLE
Only use `__attribute__((constructor))` if supported

### DIFF
--- a/include/dicom/dicom.h
+++ b/include/dicom/dicom.h
@@ -19,12 +19,6 @@
 #define DCM_EXTERN __attribute__((visibility("default"))) extern
 #endif
 
-#ifdef HAS_CONSTRUCTOR
-#define DCM_CONSTRUCTOR __attribute__ ((constructor))
-#else
-#define DCM_CONSTRUCTOR __attribute__ ((constructor))
-#endif
-
 /**
  * Maximum number of characters in values with Value Representation AE.
  */
@@ -132,7 +126,6 @@ typedef struct _DcmSequence DcmSequence;
  * This function can be called many times.
  */
 DCM_EXTERN
-DCM_CONSTRUCTOR
 void dcm_init(void);
 
 /* Our copy of getopt, since non-glibc platforms are missing this.

--- a/meson.build
+++ b/meson.build
@@ -106,13 +106,7 @@ if cc.has_header('unistd.h')
     cfg.set('HAVE_UNISTD_H', '1')
 endif
 # we use a constructor attr for dcm_init()
-code = '''#include<stdio.h>
-__attribute__ ((constructor)) void func() { printf("constructor\n"); }
-'''
-cfg.set(
-  'HAS_CONSTRUCTOR',
-  cc.compiles(code, name : 'has constructor attribute')
-)
+cfg.set('HAS_CONSTRUCTOR', cc.has_function_attribute('constructor'))
 
 configure_file(
   output : 'config.h',

--- a/src/dicom-dict.c
+++ b/src/dicom-dict.c
@@ -5083,6 +5083,9 @@ static struct _DcmAttribute_hash_entry *attribute_from_tag_dict = NULL;
 static struct _DcmAttribute_hash_entry *attribute_from_keyword_dict = NULL;
 
 
+#ifdef HAS_CONSTRUCTOR
+__attribute__ ((constructor))
+#endif
 void dcm_init(void)
 {
     if (!vrtable_from_str_dict) {


### PR DESCRIPTION
The `HAS_CONSTRUCTOR` check didn't do anything, since we tried to use `__attribute__((constructor))` whether it was defined or not.  That caused a build failure on MSVC.

Also, we shouldn't add the constructor attribute from a public header, since it's only relevant while building the library, and is conditioned on a `config.h` macro that isn't visible outside the library.  Move constructor handling directly to the one call site that needs it.

While we're here, simplify the constructor support check in `meson.build`.