### PR TITLE
doc: switch back to libclang to avoid hardcoding LLVM version

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-clang <= 14
+libclang
 hawkmoth
 sphinx
 sphinx_rtd_theme

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,12 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-from glob import glob
 import os
-import sys
 from hawkmoth.util import readthedocs
 from hawkmoth.util import compiler
-from clang.cindex import Config as clang_config
 
 # -- Project information -----------------------------------------------------
 
@@ -62,20 +59,3 @@ readthedocs.clang_setup()
 hawkmoth_clang = compiler.get_include_args()
 # we need build to get version.h
 hawkmoth_clang.append(f"-I{os.path.abspath('../../build')}")
-if sys.platform == 'darwin':
-    lib_search_dirs = [
-        '/usr/lib',
-        '/usr/local/lib',
-        '/Library/Developer/CommandLineTools/usr/lib',
-    ]
-elif sys.platform == 'windows':
-    lib_search_dirs = []
-else:
-    # we are nailed to clang-14 by readthedocs, so we must look in llvm-14
-    # for libclang.so
-    lib_search_dirs = [
-        '/usr/lib',
-        '/usr/local/lib',
-    ] + glob('/usr/lib/llvm-14/lib')
-for lib_dir in lib_search_dirs:
-    clang_config.set_library_path(lib_dir)


### PR DESCRIPTION
The `libclang` package has an embedded copy of libclang, which allows us to avoid requiring the system to have a particular clang version.  This didn't work before because the `lib_search_dirs` logic in `conf.py` was clobbering a working path with a broken one.  That logic is no longer needed, so just remove it.

Tested on Fedora 38 and Ubuntu 22.04, but not specifically tested with Read the Docs.