### PR TITLE
doc: use a separate `requirements-rtd.txt` for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,12 +4,13 @@ build:
   os: "ubuntu-22.04"
   apt_packages:
     - clang
+    - libclang-dev
   tools:
     python: "3.11"
 
 python:
   install:
-    - requirements: doc/requirements.txt
+    - requirements: doc/requirements-rtd.txt
 
 sphinx:
   configuration: doc/source/conf.py

--- a/doc/requirements-rtd.txt
+++ b/doc/requirements-rtd.txt
@@ -1,0 +1,6 @@
+# Read the Docs ignores the libclang package's embedded libclang.so for some
+# reason.  Use the clang package, pinned to a version matching Ubuntu 22.04.
+clang < 15
+hawkmoth
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
RTD apparently tries to use the Ubuntu `libclang.so` even though the `libclang` Python package provides its own copy.  A docs build on vanilla Ubuntu 22.04 doesn't, and it's not clear why.  Since pinning to an older `clang` Python package is known to work, use that approach in a separate `requirements-rtd.txt`.

Install the `libclang-dev` package in RTD to get the `libclang.so` symlink, so we don't have to reinstate the search logic in `conf.py`.