### PR TITLE
workflows: switch to macOS 14 beta image to get ARM64 test coverage

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - os: ubuntu-latest
             cc: gcc
-          - os: macos-latest
+          - os: macos-14
             cc: clang
           - os: windows-latest
             cc: clang


### PR DESCRIPTION
GitHub Actions runs macOS 14 on ARM64 runners.