### PR TITLE
Call uthash `HASH_VALUE()` instead of `HASH_FUNCTION()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+* fix build with uthash \< 2.3.0 [bgilbert]
+
 ## 1.1.0, 28/3/24
 
 * deprecate `dcm_init()` [bgilbert]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+## 1.1.0, 28/3/24
+
 * deprecate `dcm_init()` [bgilbert]
 * improve memory usage [bgilbert]
 * fix docs build with LLVM != 14 [bgilbert]

--- a/src/dicom-dict-build.c
+++ b/src/dicom-dict-build.c
@@ -43,7 +43,7 @@ static void make_table(const char *name, const void *items, int count,
         }
         int this_key_len = key_len ? key_len : (int) strlen(KEY(i));
         unsigned hash;
-        HASH_FUNCTION(KEY(i), this_key_len, hash);
+        HASH_VALUE(KEY(i), this_key_len, hash);
         int cell, probe;
         for (probe = 0, cell = hash % table_len;
              probe < MAX_PROBES && table[cell] != EMPTY;

--- a/src/dicom-dict.c
+++ b/src/dicom-dict.c
@@ -26,7 +26,7 @@
 
 #define LOOKUP(table, field, hash, key, key_len, out) do {		\
         unsigned hash_value;						\
-        HASH_FUNCTION(key, key_len, hash_value);			\
+        HASH_VALUE(key, key_len, hash_value);				\
         for (int probe = 0; true; probe++) {				\
             int i = hash ## _dict[(hash_value + probe) % hash ## _len];	\
             if (i == hash ## _empty || probe == LOOKUP_MAX_PROBES) {	\


### PR DESCRIPTION
`HASH_FUNCTION()` is an extension point, not part of the public API.  Use `HASH_VALUE()` instead.  The former happens to work with uthash &ge; 2.3.0, but not with older versions.

Fixes build with `uthash-static` from RHEL 8.

Also update changelog for 1.1.0 release.