### PR TITLE
Explicitly fail if macOS universal build is attempted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 * fix build with uthash \< 2.3.0 [bgilbert]
+* explicitly fail if macOS universal build is attempted [bgilbert]
 
 ## 1.1.0, 28/3/24
 

--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,13 @@ version_data.set10('DCM_STATIC', get_option('default_library') == 'static')
 
 # dependencies
 cc = meson.get_compiler('c')
+if host_machine.system() == 'darwin' and not cc.has_header('stdio.h')
+  # Certain compiler checks fail with -arch x86_64 -arch arm64.  Detect this
+  # in advance.
+  # https://github.com/mesonbuild/meson/issues/5290
+  # https://github.com/mesonbuild/meson/issues/8206
+  error('Basic environment check failed.  Check compiler flags; building for multiple CPU architectures is not supported.')
+endif
 found_uthash = cc.check_header(
   'utarray.h',
   required : false


### PR DESCRIPTION
Certain Meson compiler checks fail if CFLAGS has `-arch x86_64 -arch arm64`.  This was causing us not to set `HAVE_UNISTD_H`, and then to fail the build on an implicit function declaration.  Detect this configuration during setup and fail with a clearer error.

https://trac.macports.org/ticket/69676