### PR TITLE
workflows: switch back to `macos-latest`

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - os: ubuntu-latest
             cc: gcc
-          - os: macos-14
+          - os: macos-latest
             cc: clang
           - os: windows-latest
             cc: clang


### PR DESCRIPTION
It's now an alias for `macos-14`.  Switch back so we get future OS updates.