### PR TITLE
don't trim spaces from numeric fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * fix build with uthash \< 2.3.0 [bgilbert]
 * explicitly fail if macOS universal build is attempted [bgilbert]
 * better handling of implicit mode in dcm-dump [jcupitt]
+* better handling of trailing spaces in string values [y-baba-isb]
 
 ## 1.1.0, 28/3/24
 

--- a/src/dicom-parse.c
+++ b/src/dicom-parse.c
@@ -616,12 +616,12 @@ static bool parse_element_body(DcmParseState *state,
             }
             value[length] = '\0';
 
-            if (length > 0) {
-                if (vr != DCM_VR_UI) {
-                    if (isspace(value[length - 1])) {
-                        value[length - 1] = '\0';
-                    }
-                }
+            if (length > 0 &&
+                (vr_class == DCM_VR_CLASS_STRING_SINGLE ||
+                 vr_class == DCM_VR_CLASS_STRING_MULTI) &&
+                vr != DCM_VR_UI &&
+                isspace(value[length - 1])) {
+                value[length - 1] = '\0';
             }
 
             if (size > 0 && state->big_endian) {


### PR DESCRIPTION
We were accidentally trimming space characters from the end of numeric fields.

See https://github.com/ImagingDataCommons/libdicom/issues/89

Thanks @y-baba-isb