### PR TITLE
Fix unit tests in CI; fix GCC warning

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -79,8 +79,8 @@ jobs:
         $sudo meson install -C builddir
 
     - name: Rebuild the shared library cache
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo ldconfig
+      if: startsWith(matrix.os, 'ubuntu')
+      run: sudo ldconfig
 
     - name: Run unit tests
       # Don't run tests for private copy of Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * much faster read of files with an EOT but no FGS [pcram-techcyte]
 * add `dcm_filehandle_get_frame_number()` [jcupitt]
 * add DICOM catenation support [jcupitt]
+* fix GCC compiler warning [bgilbert]
 
 ## 1.1.0, 28/3/24
 

--- a/tests/check_dicom.c
+++ b/tests/check_dicom.c
@@ -303,7 +303,7 @@ START_TEST(test_element_CS_multivalue_empty)
     uint32_t vm = 0;
 
     // since malloc(0) can be NULL on some platforms
-    char **values = malloc(1);
+    char **values = malloc(sizeof(char *));
 
     DcmElement *element = dcm_element_create(NULL, tag, DCM_VR_CS);
     (void) dcm_element_set_value_string_multi(NULL, element, values, vm, true);


### PR DESCRIPTION
GitHub was not running tests:

    Invalid workflow file: .github/workflows/run_unit_tests.yml#L82
    You have an error in your yaml syntax on line 82

GCC warning:

    ../tests/check_dicom.c: In function ‘test_element_CS_multivalue_empty_fn’:
    ../tests/check_dicom.c:306:21: warning: allocation of insufficient size ‘1’ for type ‘char *’ with size ‘8’ [-Walloc-size]