### PR TITLE
workflows: run tests on Linux ARM

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -16,6 +16,8 @@ jobs:
         include:
           - os: ubuntu-latest
             cc: gcc
+          - os: ubuntu-24.04-arm
+            cc: gcc
           - os: macos-latest
             cc: clang
           - os: windows-latest


### PR DESCRIPTION
Public runners are [now available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).