### PR TITLE
Leave room in `_DcmAttribute` to NUL-terminate a 63-character keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 
+* fix one-byte overread into struct padding [bgilbert]
+
 ## 1.2.0, 09/04/2025
 
 * fix build with uthash \< 2.3.0 [bgilbert]

--- a/src/dicom-dict-tables.h
+++ b/src/dicom-dict-tables.h
@@ -68,7 +68,7 @@ typedef enum _DcmVRTag {
 struct _DcmAttribute {
     uint32_t tag;
     DcmVRTag vr_tag;
-    char keyword[63];
+    char keyword[64];
 };
 
 extern const struct _DcmAttribute dcm_attribute_table[];


### PR DESCRIPTION
`FrameOfReferenceToDisplayedCoordinateSystemTransformationMatrix` is 63 characters and we need room for the trailing NUL.  While the compiler would have added a trailing 0 byte anyway to maintain struct alignment, reading the string would invoke undefined behavior.

Fixes a warning on GCC 15:

    ../src/dicom-dict-tables.c:3296:33: warning: initializer-string for array of ‘char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (64 chars into 63 available) [-Wunterminated-string-initialization]
     3296 |     {0X0070030B, DCM_VR_TAG_FD, "FrameOfReferenceToDisplayedCoordinateSystemTransformationMatrix"}