### PR TITLE
Meson updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,9 @@ indent_size = 4
 [*.py]
 indent_style = space
 indent_size = 4
+
+[meson.build]
+indent_size = 2
+
+[meson_options.txt]
+indent_size = 2

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -50,7 +50,11 @@ jobs:
 
     - name: Install build and test dependencies (Windows)
       if: startsWith(matrix.os, 'windows')
-      run: pip install meson ninja
+      run: |
+        # remove broken pkg-config that causes Meson warnings
+        del 'C:\\Strawberry\\perl\\bin\\pkg-config'
+        del 'C:\\Strawberry\\perl\\bin\\pkg-config.BAT'
+        pip install meson ninja
 
     - name: Build and install library
       shell: bash
@@ -76,7 +80,7 @@ jobs:
             esac
             ;;
         esac
-        meson setup builddir --werror $setup_args
+        meson setup builddir --fatal-meson-warnings --werror $setup_args
         DEBUG_DICT=1 meson compile -C builddir
         $sudo meson install -C builddir
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tags
 # Subprojects
+/subprojects/.wraplock
 /subprojects/packagecache
 /subprojects/check-*
 /subprojects/uthash-*

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ project(
     'buildtype=debugoptimized',
   ],
   license : 'MIT',
-  meson_version : '>=0.50',
+  meson_version : '>=0.55',
   version : '1.2.0'
 )
 if not meson.is_subproject()
@@ -82,10 +82,7 @@ if found_uthash
 else
   # fall back to dependency() rather than subproject() so
   # --wrap-mode=nofallback works
-  uthash = dependency(
-    'uthash',
-    fallback : ['uthash', 'uthash_dep'],
-  )
+  uthash = dependency('uthash')
 endif
 if get_option('tests')
   check = dependency(
@@ -93,7 +90,6 @@ if get_option('tests')
     default_options : [
       'warning_level=0',
     ],
-    fallback : ['check', 'check_dep'],
     version : '>=0.9.6',
   )
 endif
@@ -195,9 +191,7 @@ libdicom_dep = declare_dependency(
   include_directories : [library_includes, include_directories('.')],
   link_with : libdicom,
 )
-if meson.version().version_compare('>=0.54')
-  meson.override_dependency('libdicom', libdicom_dep)
-endif
+meson.override_dependency('libdicom', libdicom_dep)
 
 # tools
 executable(

--- a/meson.build
+++ b/meson.build
@@ -246,6 +246,7 @@ if get_option('tests')
     'check_dicom',
     'tests/check_dicom.c',
     dependencies : [check, libdicom_dep],
+    build_by_default : false,
   )
   test('check_dicom', check_dicom)
 endif

--- a/meson.build
+++ b/meson.build
@@ -146,7 +146,7 @@ library_includes = include_directories('include')
 library_options = ['-DBUILDING_LIBDICOM']
 dict_build = executable(
   'dicom-dict-build',
-  ['src/dicom-dict-build.c', 'src/dicom-dict-tables.c'],
+  files('src/dicom-dict-build.c', 'src/dicom-dict-tables.c'),
   dependencies : [uthash],
   include_directories : library_includes,
   native : true,
@@ -156,17 +156,16 @@ dict_lookup = custom_target(
   command : [dict_build, '@OUTPUT@'],
   output : ['dicom-dict-lookup.c', 'dicom-dict-lookup.h'],
 )
-library_sources = [
-  dict_lookup,
-  'src/getopt.c',
-  'src/dicom.c',
-  'src/dicom-io.c',
+library_sources = [dict_lookup] + files(
   'src/dicom-data.c',
-  'src/dicom-dict.c',
   'src/dicom-dict-tables.c',
+  'src/dicom-dict.c',
   'src/dicom-file.c',
+  'src/dicom-io.c',
   'src/dicom-parse.c',
-]
+  'src/dicom.c',
+  'src/getopt.c',
+)
 libdicom = library(
   'dicom',
   library_sources,
@@ -227,7 +226,7 @@ subdir('doc/env/bin')
 custom_target(
   'html',
   command : [sphinx_build, '@SOURCE_ROOT@/doc/source', '@OUTPUT@'],
-  input : [
+  input : files(
     'doc/source/api.rst',
     'doc/source/conf.py',
     'doc/source/contributing.rst',
@@ -237,7 +236,7 @@ custom_target(
     'doc/source/tools.rst',
     'doc/source/usage.rst',
     'include/dicom/dicom.h',
-  ],
+  ),
   output : 'html',
 )
 

--- a/meson.build
+++ b/meson.build
@@ -10,12 +10,10 @@ project(
   ],
   license : 'MIT',
   meson_version : '>=0.55',
-  version : '1.2.0'
+  version : '1.2.0',
 )
 if not meson.is_subproject()
-  meson.add_dist_script(
-    'scripts/dist.py'
-  )
+  meson.add_dist_script('scripts/dist.py')
 endif
 
 # project version
@@ -46,7 +44,7 @@ abi_version = '@0@.@1@.@2@'.format(
 )
 darwin_library_versions = [
   abi_version_major + 1,
-  '@0@.@1@'.format(abi_version_major + 1, abi_version_minor)
+  '@0@.@1@'.format(abi_version_major + 1, abi_version_minor),
 ]
 
 # ready to be pasted into source files
@@ -68,14 +66,16 @@ if host_machine.system() == 'darwin' and not cc.has_header('stdio.h')
   # in advance.
   # https://github.com/mesonbuild/meson/issues/5290
   # https://github.com/mesonbuild/meson/issues/8206
-  error('Basic environment check failed.  Check compiler flags; building for multiple CPU architectures is not supported.')
+  error(
+    'Basic environment check failed.  Check compiler flags; building for multiple CPU architectures is not supported.',
+  )
 endif
 found_uthash = cc.check_header(
   'utarray.h',
-  required : false
+  required : false,
 ) and cc.check_header(
   'uthash.h',
-  required : false
+  required : false,
 )
 if found_uthash
   uthash = declare_dependency()
@@ -105,10 +105,10 @@ cfg.set_quoted(
 )
 
 if cc.has_header('io.h')
-    cfg.set('HAVE_IO_H', '1')
+  cfg.set('HAVE_IO_H', '1')
 endif
 if cc.has_header('unistd.h')
-    cfg.set('HAVE_UNISTD_H', '1')
+  cfg.set('HAVE_UNISTD_H', '1')
 endif
 
 configure_file(
@@ -130,9 +130,9 @@ add_project_arguments(
 
 # include
 version_header = configure_file(
-    input : 'include/dicom/version.h.in',
-    output : 'version.h',
-    configuration : version_data,
+  input : 'include/dicom/version.h.in',
+  output : 'version.h',
+  configuration : version_data,
 )
 
 install_headers(
@@ -175,7 +175,7 @@ libdicom = library(
   version : abi_version,
   darwin_versions : darwin_library_versions,
   include_directories : library_includes,
-  gnu_symbol_visibility: 'hidden',
+  gnu_symbol_visibility : 'hidden',
   install : true,
 )
 import('pkgconfig').generate(

--- a/meson.format
+++ b/meson.format
@@ -1,0 +1,4 @@
+kwargs_force_multiline = true
+sort_files = true
+use_editor_config = true
+wide_colon = true

--- a/scripts/meson-format.sh
+++ b/scripts/meson-format.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec meson format -c meson.format -i -r

--- a/subprojects/check.wrap
+++ b/subprojects/check.wrap
@@ -3,11 +3,12 @@ directory = check-0.15.2
 source_url = https://github.com/libcheck/check/archive/0.15.2.tar.gz
 source_filename = check-0.15.2.tar.gz
 source_hash = 998d355294bb94072f40584272cf4424571c396c631620ce463f6ea97aa67d2e
-patch_filename = check_0.15.2-4_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/check_0.15.2-4/get_patch
-patch_hash = 3e998eb0c475613e890c9e006420fb6da5dcee27aa2ba3f331f9253648691743
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/check_0.15.2-4/check-0.15.2.tar.gz
-wrapdb_version = 0.15.2-4
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/check_0.15.2-6/get_source/check-0.15.2.tar.gz
+patch_filename = check_0.15.2-6_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/check_0.15.2-6/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/check_0.15.2-6/check_0.15.2-6_patch.zip
+patch_hash = ff3bebb5801fae479ab3686d95f91a77b572751eb891d9b9804933e8b9da94eb
+wrapdb_version = 0.15.2-6
 
 [provide]
-check = check_dep
+dependency_names = check

--- a/subprojects/uthash.wrap
+++ b/subprojects/uthash.wrap
@@ -3,10 +3,11 @@ directory = uthash-2.3.0
 source_url = https://github.com/troydhanson/uthash/archive/v2.3.0.tar.gz
 source_filename = uthash-2.3.0.tar.gz
 source_hash = e10382ab75518bad8319eb922ad04f907cb20cccb451a3aa980c9d005e661acc
-patch_filename = uthash_2.3.0-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/uthash_2.3.0-1/get_patch
-patch_hash = d0b7cf9788c3735ee6a08bb649c58be1f5fad4b95e50e7681cbdf44882da9d7e
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/uthash_2.3.0-2/uthash-2.3.0.tar.gz
+patch_filename = uthash_2.3.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/uthash_2.3.0-2/get_patch
+patch_hash = d66806488ebd37246a160f62779e3eb3259b8cd35a978f7499daa0390923cd99
+wrapdb_version = 2.3.0-2
 
 [provide]
-uthash = uthash_dep
-
+dependency_names = uthash


### PR DESCRIPTION
Notably, require Meson &ge; 0.55 to fix a Meson warning, since older versions aren't really relevant now.  Build in CI with `--fatal-meson-warnings` so Meson warnings are noticed promptly.

There's obviously some deck-chair rearrangement going on here, so let me know if you want any of these commits dropped.