### PR TITLE
Reduce seeks on file io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * support single-frame DICOM images and allow BitsStored > 8 [tokyovigilante]
 * fix error handling for string values over max length [arngaillard]
 * add `-w` (show warnings) to dcm-dump and dcm-getframe
+* reduce seeks on file io [rvause]
 
 ## 1.2.0, 09/04/2025
 
@@ -55,4 +56,3 @@
 ## 1.0.0, 2/10/23
 
 * first release!
-

--- a/src/dicom-file.c
+++ b/src/dicom-file.c
@@ -1370,7 +1370,8 @@ DcmFrame *dcm_filehandle_read_frame(DcmError **error,
     char* frame_data = NULL;
     if (dcm_is_encapsulated_transfer_syntax(syntax)) {
         int64_t frame_end_offset = frame_number < filehandle->num_frames ?
-                                   filehandle->offset_table[i + 1] : 0xFFFFFFFF;
+                                   (filehandle->offset_table[i + 1] -
+                                    filehandle->offset_table[i]) : 0xFFFFFFFF;
         frame_data = dcm_parse_encapsulated_frame(error,
                                                   filehandle->io,
                                                   filehandle->implicit,

--- a/src/dicom-io.c
+++ b/src/dicom-io.c
@@ -46,6 +46,7 @@ typedef struct _DcmIOFile {
     char input_buffer[BUFFER_SIZE];
     int64_t bytes_in_buffer;
     int64_t read_point;
+    int64_t offset;
 } DcmIOFile;
 
 
@@ -154,6 +155,7 @@ static int64_t refill(DcmError **error, DcmIOFile *file)
 
     file->read_point = 0;
     file->bytes_in_buffer = bytes_read;
+    file->offset += bytes_read;
 
     return bytes_read;
 }
@@ -202,42 +204,62 @@ static int64_t dcm_io_seek_file(DcmError **error, DcmIO *io,
 {
     DcmIOFile *file = (DcmIOFile *) io;
 
-    /* We've read ahead by some number of buffered bytes, so first undo that,
-     * then do the seek from the true position.
+    /* Translate the request to an absolute target. The logical position the
+     * caller perceives is offset - bytes_in_buffer + read_point.
      */
-    int64_t new_offset;
+    int64_t logical_pos = file->offset - file->bytes_in_buffer +
+                          file->read_point;
+    int64_t target;
 
-    int64_t bytes_ahead = file->bytes_in_buffer - file->read_point;
-    if (bytes_ahead > 0) {
-#ifdef _WIN32
-        new_offset = _lseeki64(file->fd, -bytes_ahead, SEEK_CUR);
-#else
-        new_offset = lseek(file->fd, -bytes_ahead, SEEK_CUR);
-#endif
+    switch (whence) {
+        case SEEK_SET:
+            target = offset;
+            break;
+        case SEEK_CUR:
+            target = logical_pos + offset;
+            break;
+        case SEEK_END:
+        default:
+            target = -1;
+            break;
+    }
 
-        if (new_offset < 0) {
-            dcm_error_set(error, DCM_ERROR_CODE_IO,
-                "unable to seek file",
-                "unable to seek %s - %s", file->filename, strerror(errno));
+    /* If we know the absolute target and it falls within the
+     * currently-buffered window (offset - bytes_in_buffer, offset), we can
+     * skip the seek entirely.
+     */
+    if (target >= 0) {
+        int64_t buffer_base = file->offset - file->bytes_in_buffer;
+        if (target >= buffer_base && target <= file->offset) {
+            file->read_point = target - buffer_base;
+            return target;
         }
     }
 
+    /* For SEEK_SET / SEEK_CUR we always use SEEK_SET with the resulting
+     * absolute target.
+     */
+    int64_t new_offset;
+    int seek_whence = (target >= 0) ? SEEK_SET : whence;
+    int64_t seek_offset = (target >= 0) ? target : offset;
 #ifdef _WIN32
-    new_offset = _lseeki64(file->fd, offset, whence);
+    new_offset = _lseeki64(file->fd, seek_offset, seek_whence);
 #else
-    new_offset = lseek(file->fd, offset, whence);
+    new_offset = lseek(file->fd, seek_offset, seek_whence);
 #endif
 
     if (new_offset < 0) {
         dcm_error_set(error, DCM_ERROR_CODE_IO,
             "unable to seek file",
             "unable to seek %s - %s", file->filename, strerror(errno));
+        return new_offset;
     }
 
-    /* Empty the buffer, since we may now be at a different position.
+    /* Empty the buffer; the next read will refill it from the new position.
      */
     file->bytes_in_buffer = 0;
     file->read_point = 0;
+    file->offset = new_offset;
 
     return new_offset;
 }
@@ -399,4 +421,3 @@ int64_t dcm_io_seek(DcmError **error,
 {
     return io->methods->seek(error, io, offset, whence);
 }
-

--- a/src/dicom-parse.c
+++ b/src/dicom-parse.c
@@ -1060,10 +1060,11 @@ char *dcm_parse_encapsulated_frame(DcmError **error,
     uint32_t tag;
     uint32_t fragment_length = 0;
     uint64_t frame_length = 0;
+    char *value = NULL;
 
-    // first determine the total length of bytes to be read
     while (position < frame_end_offset) {
         if (!read_tag(&state, &tag, &position)) {
+            free(value);
             return NULL;
         }
         if (tag == TAG_SQ_DELIM) {
@@ -1073,49 +1074,37 @@ char *dcm_parse_encapsulated_frame(DcmError **error,
             dcm_error_set(error, DCM_ERROR_CODE_PARSE,
                           "reading frame item failed",
                           "no item tag found for frame item");
-            return NULL;
-        }
-        if (!read_uint32(&state, &fragment_length, &position)) {
-            return NULL;
-        }
-        dcm_seekcur(&state, fragment_length, &position);
-        frame_length += fragment_length;
-    }
-    if (frame_length > 0xFFFFFFFF) {
-        dcm_error_set(error, DCM_ERROR_CODE_PARSE,
-                      "invalid frame size",
-                      "frame size exceeds 4GB" );
-        return NULL;
-    }
-
-    char *value = DCM_MALLOC(error, frame_length);
-    if (value == NULL) {
-        return NULL;
-    }
-    // if frame end is unknown/undefined then update it
-    if (frame_end_offset == 0xFFFFFFFF) {
-        frame_end_offset = position;
-    }
-    // reposition to the beginning of encapsulated pixel data
-    dcm_seekcur(&state, -position, &position);
-
-    fragment_length = 0;
-    char* fragment = value;
-    position = 0;
-    while (position < frame_end_offset) {
-        if (!read_tag(&state, &tag, &position)) {
-            return NULL;
-        }
-        if (tag == TAG_SQ_DELIM) {
-            break;
-        }
-        if (!read_uint32(&state, &fragment_length, &position) ||
-            !dcm_require(&state, fragment, fragment_length, &position)) {
             free(value);
             return NULL;
         }
-        fragment += fragment_length;
+        if (!read_uint32(&state, &fragment_length, &position)) {
+            free(value);
+            return NULL;
+        }
+        if (frame_length + fragment_length > 0xFFFFFFFF) {
+            dcm_error_set(error, DCM_ERROR_CODE_PARSE,
+                          "invalid frame size",
+                          "frame size exceeds 4GB");
+            free(value);
+            return NULL;
+        }
+
+        char *new_value = (char *) dcm_realloc(error, value,
+                                               frame_length + fragment_length);
+        if (new_value == NULL) {
+            free(value);
+            return NULL;
+        }
+        value = new_value;
+
+        if (!dcm_require(&state, value + frame_length, fragment_length,
+                         &position)) {
+            free(value);
+            return NULL;
+        }
+        frame_length += fragment_length;
     }
+
     *length = (uint32_t) frame_length;
 
     return value;


### PR DESCRIPTION
I was noticing very slow read times of dicom file regions using openslide. This issue was somewhat hidden until the code was running in an environment with a virtual filesystem (kubernetes managed containers). In such cases every seek and read incurs a noticeable cost.

Tracked the issue down to libdicom's file io behaviour. Using helper tool I am including here in the description it is apparent that the io layer is making many more `lseek` calls than necessary.

Made two changes that work together to reduce the number of calls being made. In `dcm_io_seek_file` use an absolute target and handle the cases where no seek is needed when target lands within the buffered window. Updated `dcm_parse_encapsulated_frame` to a single pass, using `dcm_realloc` to grow the allocated buffer.

Inspecting across reading the first 50 frames in y-x arrangement with `strace -e trace=lseek -f builddir/dcm-visit -n 50 file.dcm | grep 'lseek(' | wc -l` results in `3428` calls.
Adding the `-r` flag to read in x-y arrangement, this results in `672386` calls for this particular file.

With the patch included here, both variants are uniform in `99` calls for reading these 50 frames.

As a way to demonstrate the overall improvement using `vips tiffsave` will read the entire full resolution dicom image. Run on a linux vm using virtiofs with 8 cores.

Before:
```
vips tiffsave --vips-progress --tile CMU-1/DCM_0.dcm out.tiff
vips temp-1: 46000 x 32893 pixels, 8 threads, 128 x 128 tiles, 256 lines in buffer
vips temp-1: done in 320s
```

After:
```
vips tiffsave --vips-progress --tile CMU-1/DCM_0.dcm out.tiff
vips temp-1: 46000 x 32893 pixels, 8 threads, 128 x 128 tiles, 256 lines in buffer
vips temp-1: done in 20.6s
```

`dcm-visit.c`
```c
#include <dicom/dicom.h>
#include <stdint.h>
#include <stdio.h>
#include <stdlib.h>

typedef int64_t i64;
typedef uint32_t u32;

static const char usage[] = "usage: dcm-visit [-hviwnr] FILE_PATH ...";
static const char TotalPixelMatrixColums[] = "TotalPixelMatrixColumns";
static const char TotalPixelMatrixRows[] = "TotalPixelMatrixRows";
static const char Columns[] = "Columns";
static const char Rows[] = "Rows";

static bool get_dataset_int(const DcmDataSet *ds, const char *tag_name,
                            i64 *out) {
  u32 tag = dcm_dict_tag_from_keyword(tag_name);
  DcmElement *el = dcm_dataset_get(NULL, ds, tag);
  return el && dcm_element_get_value_integer(NULL, el, 0, out);
}

int main(int argc, char *argv[]) {
  int c;
  i64 n_frames = 0;
  bool reverse = false;
  while ((c = dcm_getopt(argc, argv, "hviwn:r")) != -1) {
    switch (c) {
    case 'h':
      printf("%s\n", usage);
      return EXIT_SUCCESS;

    case 'v':
    case 'i':
      dcm_log_set_level(DCM_LOG_INFO);
      break;

    case 'w':
      dcm_log_set_level(DCM_LOG_WARNING);
      break;

    case 'n':
      n_frames = (i64)atoi(dcm_optarg);
      break;

    case 'r':
      reverse = true;
      break;

    case '#':
    default:
      return EXIT_FAILURE;
    }
  }

  DcmError *error = NULL;

  if (dcm_optind + 1 != argc) {
    fprintf(stderr, "%s\n", usage);
    return EXIT_FAILURE;
  }
  const char *input_file = argv[dcm_optind];

  dcm_log_info("Read filehandle '%s'", input_file);
  DcmFilehandle *filehandle =
      dcm_filehandle_create_from_file(&error, input_file);

  if (filehandle == NULL) {
    dcm_error_print(error);
    dcm_error_clear(&error);
    return EXIT_FAILURE;
  }

  const DcmDataSet *metadata =
      dcm_filehandle_get_metadata_subset(&error, filehandle);

  if (metadata == NULL) {
    dcm_error_print(error);
    dcm_error_clear(&error);
    dcm_filehandle_destroy(filehandle);
    return EXIT_FAILURE;
  }

  i64 frame_w, frame_h, width, height;
  if (!get_dataset_int(metadata, Rows, &frame_h) ||
      !get_dataset_int(metadata, Columns, &frame_w) ||
      !get_dataset_int(metadata, TotalPixelMatrixRows, &height) ||
      !get_dataset_int(metadata, TotalPixelMatrixColums, &width)) {
    fprintf(stderr, "Failed to determine image dimensions\n");
    dcm_filehandle_destroy(filehandle);
    return EXIT_FAILURE;
  }

  i64 tiles_x = (width / frame_w) + !!(width % frame_w);
  i64 tiles_y = (height / frame_h) + !!(height % frame_h);

  dcm_log_warning("tiles %dx%d", tiles_x, tiles_y);

  i64 max_a, max_b;

  if (!reverse) {
      max_a = tiles_y;
      max_b = tiles_x;
  } else {
      max_a = tiles_x;
      max_b = tiles_y;
  }

  u32 read_frames = 0;
  for (i64 a = 0; a < max_a; a++) {
    for (i64 b = 0; b < max_b; b++) {
      u32 num = 0;
      i64 x = reverse ? a : b;
      i64 y = reverse ? b : a;
      if (dcm_filehandle_get_frame_number(NULL, filehandle, x, y, &num)) {
        dcm_log_info("tile %dx%d = %d", x, y, num);
        DcmFrame *frame = dcm_filehandle_read_frame(&error, filehandle, num);
        if (frame == NULL) {
          dcm_error_print(error);
          dcm_error_clear(&error);
          dcm_filehandle_destroy(filehandle);
          return EXIT_FAILURE;
        }
        dcm_frame_destroy(frame);
        read_frames++;
        if (read_frames >= n_frames) {
          goto end;
        }
      }
    }
  }
end:
  dcm_log_info("Cleaning up...");
  dcm_filehandle_destroy(filehandle);
  return EXIT_SUCCESS;
}
```