### PR TITLE
Don't log ignored errors unless debug logging is enabled

### DIFF
--- a/src/dicom.c
+++ b/src/dicom.c
@@ -377,11 +377,18 @@ static void dcm_logf(const char *level, const char *format, va_list args)
 }
 
 
+static bool should_log(DcmLogLevel level)
+{
+    return dcm_log_level <= level &&
+           (level == DCM_LOG_CRITICAL || dcm_log_level > DCM_LOG_NOTSET);
+}
+
+
 void dcm_log_critical(const char *format, ...)
 {
     dcm_init();
 
-    if (dcm_log_level <= DCM_LOG_CRITICAL) {
+    if (should_log(DCM_LOG_CRITICAL)) {
         va_list(args);
         va_start(args, format);
         dcm_logf("CRITICAL", format, args);
@@ -394,7 +401,7 @@ void dcm_log_error(const char *format, ...)
 {
     dcm_init();
 
-    if ((dcm_log_level > DCM_LOG_NOTSET) & (dcm_log_level <= DCM_LOG_ERROR)) {
+    if (should_log(DCM_LOG_ERROR)) {
         va_list(args);
         va_start(args, format);
         dcm_logf("ERROR   ", format, args);
@@ -407,7 +414,7 @@ void dcm_log_warning(const char *format, ...)
 {
     dcm_init();
 
-    if ((dcm_log_level > DCM_LOG_NOTSET) & (dcm_log_level <= DCM_LOG_WARNING)) {
+    if (should_log(DCM_LOG_WARNING)) {
         va_list(args);
         va_start(args, format);
         dcm_logf("WARNING ", format, args);
@@ -420,7 +427,7 @@ void dcm_log_info(const char *format, ...)
 {
     dcm_init();
 
-    if ((dcm_log_level > DCM_LOG_NOTSET) & (dcm_log_level <= DCM_LOG_INFO)) {
+    if (should_log(DCM_LOG_INFO)) {
         va_list(args);
         va_start(args, format);
         dcm_logf("INFO    ", format, args);
@@ -433,7 +440,7 @@ void dcm_log_debug(const char *format, ...)
 {
     dcm_init();
 
-    if ((dcm_log_level > DCM_LOG_NOTSET) & (dcm_log_level <= DCM_LOG_DEBUG)) {
+    if (should_log(DCM_LOG_DEBUG)) {
         va_list(args);
         va_start(args, format);
         dcm_logf("DEBUG   ", format, args);

--- a/src/dicom.c
+++ b/src/dicom.c
@@ -219,6 +219,8 @@ static DcmError *dcm_error_newf(DcmErrorCode code,
 }
 
 
+static bool should_log(DcmLogLevel level);
+
 void dcm_error_set(DcmError **error, DcmErrorCode code,
     const char *summary, const char *format, ...)
 {
@@ -233,7 +235,7 @@ void dcm_error_set(DcmError **error, DcmErrorCode code,
         va_start(ap, format);
         *error = dcm_error_newf(code, summary, format, ap);
         va_end(ap);
-    } else {
+    } else if (should_log(DCM_LOG_DEBUG)) {
         /* Log to DEBUG so messages don't get completely lost.
          */
         va_list(ap);


### PR DESCRIPTION
Avoid the `dcm_error_newf()` and `dcm_error_free()` if we won't log the message anyway.

With the current state of https://github.com/openslide/openslide/pull/648, this avoids allocating, string-formatting, and freeing 690,658 `dcm_filehandle_get_frame_number()` errors when opening [3DHISTECH-2](https://openslide.cs.cmu.edu/download/openslide-testdata/DICOM/3DHISTECH-2.zip):

```
Before:
real	0m0.303s
user	0m0.224s
sys	0m0.077s

After:
real	0m0.210s
user	0m0.133s
sys	0m0.077s
```