### PR TITLE
RFC: Return preallocated error for `DCM_ERROR_CODE_MISSING_FRAME`

### DIFF
--- a/src/dicom-file.c
+++ b/src/dicom-file.c
@@ -1431,18 +1431,16 @@ bool dcm_filehandle_get_frame_number(DcmError **error,
     if (filehandle->layout == DCM_LAYOUT_SPARSE) {
         index = filehandle->frame_index[index];
         if (index == 0xffffffff) {
-            dcm_error_set(error, DCM_ERROR_CODE_MISSING_FRAME,
-                          "no frame",
-                          "no frame at position (%u, %u)", column, row);
+            // we might return this error hundreds of thousands of times;
+            // avoid allocating each time
+            dcm_error_set_static(error, &DCM_STATIC_ERROR_MISSING_FRAME);
             return false;
         }
     } else {
         // subtract the start of this file, for catenation support
         index -= filehandle->frame_offset;
         if (index < 0 || index >= (int64_t) filehandle->num_frames) {
-            dcm_error_set(error, DCM_ERROR_CODE_MISSING_FRAME,
-                          "no frame",
-                          "no frame at position (%u, %u)", column, row);
+            dcm_error_set_static(error, &DCM_STATIC_ERROR_MISSING_FRAME);
             return false;
         }
     }

--- a/src/dicom.c
+++ b/src/dicom.c
@@ -186,11 +186,19 @@ struct _DcmError {
     DcmErrorCode code;
     char *summary;
     char *message;
+    bool is_static;
+};
+
+const DcmError DCM_STATIC_ERROR_MISSING_FRAME = {
+    .code = DCM_ERROR_CODE_MISSING_FRAME,
+    .summary = "no frame",
+    .message = "no frame at this position",
+    .is_static = true,
 };
 
 static void dcm_error_free(DcmError *error)
 {
-    if (error) {
+    if (error && !error->is_static) {
         free(error->summary);
         error->summary = NULL;
         free(error->message);
@@ -249,6 +257,18 @@ void dcm_error_set(DcmError **error, DcmErrorCode code,
 
         dcm_error_free(local_error);
     }
+}
+
+
+void dcm_error_set_static(DcmError **error, const DcmError *static_error) {
+    if (!static_error->is_static) {
+        dcm_log_critical("DcmError is not static");
+    } else if (error && *error) {
+        dcm_log_critical("DcmError set twice");
+    } else if (error) {
+        *error = (DcmError *) static_error;
+    }
+    /* otherwise don't log; we're in a fast path */
 }
 
 

--- a/src/pdicom.h
+++ b/src/pdicom.h
@@ -65,6 +65,9 @@ char *dcm_printf_append(char *str, const char *format, ...);
 
 void dcm_free_string_array(char **strings, int n);
 
+extern const DcmError DCM_STATIC_ERROR_MISSING_FRAME;
+void dcm_error_set_static(DcmError **error, const DcmError *static_error);
+
 size_t dcm_dict_vr_size(DcmVR vr);
 uint32_t dcm_dict_vr_capacity(DcmVR vr);
 int dcm_dict_vr_header_length(DcmVR vr);


### PR DESCRIPTION
`DCM_ERROR_CODE_MISSING_FRAME` is unusual: it's returned by one function, which might be called in a tight loop by an application checking which frames are available in a `DcmFilehandle`.  As such, we don't want to incur allocation and string-formatting overhead each time a frame is missing. Return a generic preallocated `DcmError` instead, and special-case `dcm_error_free()` so we don't free it.

Pursuant to https://github.com/ImagingDataCommons/libdicom/pull/115#issuecomment-4590909187.  I'm still not sure how I feel about this solution.

`slidetool slide open 3DHISTECH-2/2` with the current state of https://github.com/openslide/openslide/pull/648:

```
Before:
real	0m0.148s
user	0m0.140s
sys	0m0.008s

After:
real	0m0.066s
user	0m0.062s
sys	0m0.004s
```